### PR TITLE
add Tween Track multiples

### DIFF
--- a/Plinth/TweenTrack.hpp
+++ b/Plinth/TweenTrack.hpp
@@ -57,15 +57,15 @@ public:
 	{
 		positionT position;
 		T value;
-		InterpolationType outType;
 		InterpolationType inType;
-		double outAmount;
+		InterpolationType outType;
 		double inAmount;
+		double outAmount;
 		Node()
-			: outType(InterpolationType::Linear)
-			, inType(InterpolationType::Linear)
-			, outAmount(0.0)
+			: inType(InterpolationType::Linear)
+			, outType(InterpolationType::Linear)
 			, inAmount(0.0)
+			, outAmount(0.0)
 		{
 		}
 		Node(const positionT& p, const T& v)
@@ -74,13 +74,19 @@ public:
 			position = p;
 			value = v;
 		}
+		Node(const positionT& p, const T& v, const double in, const double out)
+			: Node(p, v)
+		{
+			inAmount = in;
+			outAmount = out;
+			inType = inAmount == 0.0 ? InterpolationType::Linear : InterpolationType::Ease;
+			outType = outAmount == 0.0 ? InterpolationType::Linear : InterpolationType::Ease;
+		}
 		bool operator<(const Node& rhs) { return this->position < rhs.position; }
 	};
 
-	//void DEV_outputNodes();
-
 	Track();
-	void clearNodes();
+	void clear();
 	void addNode(const Node& node);
 	T getValue(const positionT& position) const;
 	void changeNodePosition(unsigned int index, const positionT& position);
@@ -92,6 +98,7 @@ public:
 	void changeNodeInterpolationTypeIn(unsigned int index, InterpolationType interpolationInType);
 	void changeNodeInterpolationTypes(unsigned int index, InterpolationType interpolationOutType, InterpolationType interpolationInType);
 	unsigned int getNodeCount() const;
+	Track& operator+=(const Node& node);
 
 private:
 	std::vector<Node> m_nodes;

--- a/Plinth/TweenTrack.inl
+++ b/Plinth/TweenTrack.inl
@@ -27,10 +27,6 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-/*
-#include <iostream> // for "DEV_" functions
-*/
-
 #ifndef PLINTH_TWEENTRACK_INL
 #define PLINTH_TWEENTRACK_INL
 
@@ -38,17 +34,6 @@ namespace plinth
 {
 	namespace Tween
 	{
-
-/*
-template <class positionT, class T, class interpolationAlphaT>
-void Piecewise<positionT, T, interpolationAlphaT>::DEV_outputNodes()
-{
-	for (auto& node : m_nodes)
-	{
-		std::cout << node.position << "       \t" << node.value << std::endl;
-	}
-}
-*/
 
 template <class positionT, class T, class interpolationAlphaT, class positionCastT>
 Track<positionT, T, interpolationAlphaT, positionCastT>::Track()
@@ -58,7 +43,7 @@ Track<positionT, T, interpolationAlphaT, positionCastT>::Track()
 }
 
 template <class positionT, class T, class interpolationAlphaT, class positionCastT>
-void Track<positionT, T, interpolationAlphaT, positionCastT>::clearNodes()
+void Track<positionT, T, interpolationAlphaT, positionCastT>::clear()
 {
 	m_nodes.clear();
 }
@@ -180,6 +165,13 @@ template <class positionT, class T, class interpolationAlphaT, class positionCas
 unsigned int Track<positionT, T, interpolationAlphaT, positionCastT>::getNodeCount() const
 {
 	return m_nodes.size();
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Track<positionT, T, interpolationAlphaT, positionCastT>& Track<positionT, T, interpolationAlphaT, positionCastT>::operator+=(const Node& node)
+{
+	this->addNode(node);
+	return *this;
 }
 
 template <class positionT, class T, class interpolationAlphaT, class positionCastT>

--- a/Plinth/TweenTrack2.hpp
+++ b/Plinth/TweenTrack2.hpp
@@ -1,0 +1,86 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Plinth
+//
+// Copyright(c) 2014-2016 M.J.Silk
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions :
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.If you use this software
+// in a product, an acknowledgment in the product documentation would be
+// appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+// M.J.Silk
+// MJSilk2@gmail.com
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef PLINTH_TWEENTRACK2_HPP
+#define PLINTH_TWEENTRACK2_HPP
+
+#include "Common.hpp"
+#include "TweenTrack.hpp"
+#include "Vector2.hpp"
+
+namespace plinth
+{
+	namespace Tween
+	{
+
+template <class positionT, class T, class interpolationAlphaT = double, class positionCastT = double>
+class Track2
+{
+public:
+	struct Node2
+	{
+		typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node nodeA, nodeB;
+		Node2()
+			: nodeA()
+			, nodeB()
+		{
+		}
+		Node2(const positionT& p, const T& a, const T& b)
+			: nodeA(p, a)
+			, nodeB(p, b)
+		{
+		}
+		Node2(const positionT& p, const T& a, const T& b, const double in, const double out)
+			: nodeA(p, a, in, out)
+			, nodeB(p, b, in, out)
+		{
+		}
+		Node2(const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& a,
+			const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& b)
+			: nodeA(a)
+			, nodeB(b)
+		{
+		}
+		bool operator<(const Node2& rhs) { return this->nodeA.position < rhs.nodeA.position; }
+	};
+
+	Track<positionT, T, interpolationAlphaT, positionCastT> a, b;
+	Track2();
+	Track2(const Track2<positionT, T, interpolationAlphaT, positionCastT>& track2);
+	Vector2<T> getValue(const positionT& position) const;
+	void clear();
+	void addNode(const Node2& node2);
+	void addNode(const unsigned int trackNumber, const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& node);
+	Track2& operator+=(const Node2& node2);
+};
+
+	} // namespace Tween
+} // namespace plinth
+#include "TweenTrack2.inl"
+#endif // PLINTH_TWEENTRACK2_HPP

--- a/Plinth/TweenTrack2.inl
+++ b/Plinth/TweenTrack2.inl
@@ -1,0 +1,97 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Plinth
+//
+// Copyright(c) 2014-2016 M.J.Silk
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions :
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.If you use this software
+// in a product, an acknowledgment in the product documentation would be
+// appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+// M.J.Silk
+// MJSilk2@gmail.com
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef PLINTH_TWEENTRACK2_INL
+#define PLINTH_TWEENTRACK2_INL
+
+namespace plinth
+{
+	namespace Tween
+	{
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Track2<positionT, T, interpolationAlphaT, positionCastT>::Track2()
+	: a()
+	, b()
+{
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Track2<positionT, T, interpolationAlphaT, positionCastT>::Track2(const Track2<positionT, T, interpolationAlphaT, positionCastT>& track2)
+	: a(track2.a)
+	, b(track2.b)
+{
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Vector2<T> Track2<positionT, T, interpolationAlphaT, positionCastT>::getValue(const positionT& position) const
+{
+	return{ a.getValue(position), b.getValue(position) };
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+void Track2<positionT, T, interpolationAlphaT, positionCastT>::clear()
+{
+	a.clear();
+	b.clear();
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+void Track2<positionT, T, interpolationAlphaT, positionCastT>::addNode(const Node2& node2)
+{
+	a.addNode(node2.nodeA);
+	b.addNode(node2.nodeB);
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+void Track2<positionT, T, interpolationAlphaT, positionCastT>::addNode(const unsigned int trackNumber, const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& node)
+{
+	switch (trackNumber)
+	{
+	case 0u:
+		a.addNode(node);
+		break;
+	case 1u:
+		b.addNode(node);
+		break;
+	default:
+		;
+	}
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Track2<positionT, T, interpolationAlphaT, positionCastT>& Track2<positionT, T, interpolationAlphaT, positionCastT>::operator+=(const Node2& node2)
+{
+	this->addNode(node2);
+	return *this;
+}
+
+	} // namespace Tween
+} // namespace plinth
+#endif // PLINTH_TWEENTRACK2_INL

--- a/Plinth/TweenTrack3.hpp
+++ b/Plinth/TweenTrack3.hpp
@@ -1,0 +1,91 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Plinth
+//
+// Copyright(c) 2014-2016 M.J.Silk
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions :
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.If you use this software
+// in a product, an acknowledgment in the product documentation would be
+// appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+// M.J.Silk
+// MJSilk2@gmail.com
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef PLINTH_TWEENTRACK3_HPP
+#define PLINTH_TWEENTRACK3_HPP
+
+#include "Common.hpp"
+#include "TweenTrack.hpp"
+#include "Vector3.hpp"
+
+namespace plinth
+{
+	namespace Tween
+	{
+
+template <class positionT, class T, class interpolationAlphaT = double, class positionCastT = double>
+class Track3
+{
+public:
+	struct Node3
+	{
+		typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node nodeA, nodeB, nodeC;
+		Node3()
+			: nodeA()
+			, nodeB()
+			, nodeC()
+		{
+		}
+		Node3(const positionT& p, const T& a, const T& b, const T& c)
+			: nodeA(p, a)
+			, nodeB(p, b)
+			, nodeC(p, c)
+		{
+		}
+		Node3(const positionT& p, const T& a, const T& b, const T& c, const double in, const double out)
+			: nodeA(p, a, in, out)
+			, nodeB(p, b, in, out)
+			, nodeC(p, c, in, out)
+		{
+		}
+		Node3(const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& a,
+			const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& b,
+			const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& c)
+			: nodeA(a)
+			, nodeB(b)
+			, nodeC(c)
+		{
+		}
+		bool operator<(const Node3& rhs) { return this->nodeA.position < rhs.nodeA.position; }
+	};
+
+	Track<positionT, T, interpolationAlphaT, positionCastT> a, b, c;
+	Track3();
+	Track3(const Track3<positionT, T, interpolationAlphaT, positionCastT>& track3);
+	Vector3<T> getValue(const positionT& position) const;
+	void clear();
+	void addNode(const Node3& node3);
+	void addNode(const unsigned int trackNumber, const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& node);
+	Track3& operator+=(const Node3& node3);
+};
+
+	} // namespace Tween
+} // namespace plinth
+#include "TweenTrack3.inl"
+#endif // PLINTH_TWEENTRACK3_HPP

--- a/Plinth/TweenTrack3.inl
+++ b/Plinth/TweenTrack3.inl
@@ -1,0 +1,104 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Plinth
+//
+// Copyright(c) 2014-2016 M.J.Silk
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions :
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.If you use this software
+// in a product, an acknowledgment in the product documentation would be
+// appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+// M.J.Silk
+// MJSilk2@gmail.com
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef PLINTH_TWEENTRACK3_INL
+#define PLINTH_TWEENTRACK3_INL
+
+namespace plinth
+{
+	namespace Tween
+	{
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Track3<positionT, T, interpolationAlphaT, positionCastT>::Track3()
+	: a()
+	, b()
+	, c()
+{
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Track3<positionT, T, interpolationAlphaT, positionCastT>::Track3(const Track3<positionT, T, interpolationAlphaT, positionCastT>& track3)
+	: a(track3.a)
+	, b(track3.b)
+	, c(track3.c)
+{
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Vector3<T> Track3<positionT, T, interpolationAlphaT, positionCastT>::getValue(const positionT& position) const
+{
+	return{ a.getValue(position), b.getValue(position), c.getValue(position) };
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+void Track3<positionT, T, interpolationAlphaT, positionCastT>::clear()
+{
+	a.clear();
+	b.clear();
+	c.clear();
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+void Track3<positionT, T, interpolationAlphaT, positionCastT>::addNode(const Node3& node3)
+{
+	a.addNode(node3.nodeA);
+	b.addNode(node3.nodeB);
+	c.addNode(node3.nodeC);
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+void Track3<positionT, T, interpolationAlphaT, positionCastT>::addNode(const unsigned int trackNumber, const typename Track<positionT, T, interpolationAlphaT, positionCastT>::Node& node)
+{
+	switch (trackNumber)
+	{
+	case 0u:
+		a.addNode(node);
+		break;
+	case 1u:
+		b.addNode(node);
+		break;
+	case 2u:
+		c.addNode(node);
+		break;
+	default:
+		;
+	}
+}
+
+template <class positionT, class T, class interpolationAlphaT, class positionCastT>
+Track3<positionT, T, interpolationAlphaT, positionCastT>& Track3<positionT, T, interpolationAlphaT, positionCastT>::operator+=(const Node3& node3)
+{
+	this->addNode(node3);
+	return *this;
+}
+
+	} // namespace Tween
+} // namespace plinth
+#endif // PLINTH_TWEENTRACK3_INL

--- a/Plinth/TweenTracks.hpp
+++ b/Plinth/TweenTracks.hpp
@@ -27,25 +27,11 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef PLINTH_BASE_ALL_HPP
-#define PLINTH_BASE_ALL_HPP
+#ifndef PLINTH_TWEENTRACKS_HPP
+#define PLINTH_TWEENTRACKS_HPP
 
-#include "Ascii.hpp"
-#include "Bezier.hpp"
-#include "Color.hpp"
-#include "File.hpp"
-#include "Generic.hpp"
-#include "IndexedMap.hpp"
-#include "Math.hpp"
-#include "NumberBase.hpp"
-#include "Random.hpp"
-#include "Ranges.hpp"
-#include "Sizes.hpp"
-#include "StringFrom.hpp"
-#include "Strings.hpp"
-#include "Tween.hpp"
-#include "TweenPiecewise.hpp"
-#include "TweenTracks.hpp"
-#include "Vectors.hpp"
+#include "TweenTrack.hpp"
+#include "TweenTrack2.hpp"
+#include "TweenTrack3.hpp"
 
-#endif // PLINTH_BASE_ALL_HPP
+#endif // PLINTH_TWEENTRACKS_HPP


### PR DESCRIPTION
added Tween Track 2 and 3 to allow multiple tracks per object. a node
can be set for all tracks at once and the value at all tracks can be
returned at once
added "TweenTracks" inclusion list to include tween track 2 and 3 as
well as the single tween track
modified "all" inclusion list to include TweenTracks instead of
TweenTrack
modified Tween Track so that clearNodes is now just clear and a node can
be added by using += operator. also removed unused development code
